### PR TITLE
make timestamp and instrumentation key optional, but add default

### DIFF
--- a/JavaScriptSDK.Interfaces/ITelemetryItem.ts
+++ b/JavaScriptSDK.Interfaces/ITelemetryItem.ts
@@ -12,12 +12,12 @@ export interface ITelemetryItem {
     /**
      * Timestamp when item was sent
      */ 
-    timestamp: Date;
+    timestamp?: Date;
 
     /**
      * Identifier of the resource that uniquely identifies which resource data is sent to
      */ 
-    instrumentationKey: string;
+    instrumentationKey?: string;
 
     /**
      * System context properties of the telemetry item, example: ip address, city etc

--- a/JavaScriptSDK/AppInsightsCore.ts
+++ b/JavaScriptSDK/AppInsightsCore.ts
@@ -108,6 +108,10 @@ export class AppInsightsCore implements IAppInsightsCore {
             // setup default ikey if not passed in
             telemetryItem.instrumentationKey = this.config.instrumentationKey;
         }
+        if(!telemetryItem.timestamp) {
+            // add default timestamp if not passed in
+            telemetryItem.timestamp = new Date();
+        }
 
         // do basic validation before sending it through the pipeline
         this._validateTelmetryItem(telemetryItem);

--- a/amd/package.json
+++ b/amd/package.json
@@ -1,6 +1,6 @@
 {
     "name": "applicationinsights-core-js",
-    "version": "0.0.65",
+    "version": "0.0.67",
     "description": "Microsoft Application Insights Core Javascript SDK",
     "main": "bundle/applicationinsights-core-js.js",
     "types": "bundle/applicationinsights-core-js.d.ts",

--- a/cjs/package.json
+++ b/cjs/package.json
@@ -1,6 +1,6 @@
 {
     "name": "applicationinsights-core-js",
-    "version": "0.0.64",
+    "version": "0.0.66",
     "description": "Microsoft Application Insights Core Javascript SDK",
     "devDependencies": {
         "grunt": "1.0.1",


### PR DESCRIPTION
- Made timestamp and instrumentation key optional in ItelemetryItem so that customers don't have to pass them every time.
- If no timestamp is passed, we will add a default value of now.
- If no instrumentation key is passed we were already adding the key used during initialize.