### PR TITLE
Export IDiagnosticLogger in core module, change from default to named export

### DIFF
--- a/JavaScriptSDK.Interfaces/IAppInsightsCore.ts
+++ b/JavaScriptSDK.Interfaces/IAppInsightsCore.ts
@@ -3,7 +3,7 @@ import { IChannelControls } from "./IChannelControls";
 import { IPlugin } from "./ITelemetryPlugin";
 import { IConfiguration } from "./IConfiguration";
 import { INotificationListener } from "./INotificationListener";
-import IDiagnosticLogger from './IDiagnosticLogger';
+import { IDiagnosticLogger } from './IDiagnosticLogger';
 
 "use strict";
 

--- a/JavaScriptSDK.Interfaces/IDiagnosticLogger.ts
+++ b/JavaScriptSDK.Interfaces/IDiagnosticLogger.ts
@@ -3,7 +3,7 @@ import { _InternalLogMessage } from "../JavaScriptSDK/DiagnosticLogger";
 
 "use strict"
 
-export default interface IDiagnosticLogger {
+export interface IDiagnosticLogger {
     /**
      * When this is true the SDK will throw exceptions to aid in debugging.
      */

--- a/JavaScriptSDK/AppInsightsCore.ts
+++ b/JavaScriptSDK/AppInsightsCore.ts
@@ -7,7 +7,7 @@ import { INotificationListener } from "../JavaScriptSDK.Interfaces/INotification
 import { EventsDiscardedReason } from "../JavaScriptSDK.Enums/EventsDiscardedReason";
 import { CoreUtils } from "./CoreUtils";
 import { NotificationManager } from "./NotificationManager";
-import IDiagnosticLogger from "../JavaScriptSDK.Interfaces/IDiagnosticLogger";
+import { IDiagnosticLogger } from "../JavaScriptSDK.Interfaces/IDiagnosticLogger";
 import { _InternalLogMessage, DiagnosticLogger } from "./DiagnosticLogger";
 import { _InternalMessageId } from "../JavaScriptSDK.Enums/LoggingEnums";
 

--- a/JavaScriptSDK/DiagnosticLogger.ts
+++ b/JavaScriptSDK/DiagnosticLogger.ts
@@ -1,7 +1,7 @@
 "use strict"
 import { IConfiguration } from "../JavaScriptSDK.Interfaces/IConfiguration"
 import { _InternalMessageId, LoggingSeverity } from "../JavaScriptSDK.Enums/LoggingEnums";
-import IDiagnosticLogging from "../JavaScriptSDK.Interfaces/IDiagnosticLogger";
+import { IDiagnosticLogger } from "../JavaScriptSDK.Interfaces/IDiagnosticLogger";
 import { CoreUtils } from "./CoreUtils";
 
 export class _InternalLogMessage{
@@ -39,7 +39,7 @@ export class _InternalLogMessage{
     }
 }
 
-export class DiagnosticLogger implements IDiagnosticLogging {
+export class DiagnosticLogger implements IDiagnosticLogger {
 
     /**
     *  Session storage key for the prefix for the key indicating message type already logged

--- a/amd/package.json
+++ b/amd/package.json
@@ -1,6 +1,6 @@
 {
     "name": "applicationinsights-core-js",
-    "version": "0.0.73",
+    "version": "0.0.75",
     "description": "Microsoft Application Insights Core Javascript SDK",
     "main": "bundle/applicationinsights-core-js.js",
     "types": "bundle/applicationinsights-core-js.d.ts",

--- a/applicationinsights-core-js.ts
+++ b/applicationinsights-core-js.ts
@@ -4,9 +4,10 @@ export { ITelemetryPlugin, IPlugin } from "./JavaScriptSDK.Interfaces/ITelemetry
 export { IAppInsightsCore } from "./JavaScriptSDK.Interfaces/IAppInsightsCore";
 export { ITelemetryItem } from "./JavaScriptSDK.Interfaces/ITelemetryItem";
 export { INotificationListener } from "./JavaScriptSDK.Interfaces/INotificationListener";
+export { IDiagnosticLogger } from "./JavaScriptSDK.Interfaces/IDiagnosticLogger";
 export { EventsDiscardedReason } from "./JavaScriptSDK.Enums/EventsDiscardedReason";
 export { AppInsightsCore } from "./JavaScriptSDK/AppInsightsCore";
 export { CoreUtils } from "./JavaScriptSDK/CoreUtils";
 export { NotificationManager } from "./JavaScriptSDK/NotificationManager";
-export {DiagnosticLogger, _InternalLogMessage} from './JavaScriptSDK/DiagnosticLogger';
-export {_InternalMessageId, LoggingSeverity} from './JavaScriptSDK.Enums/LoggingEnums';
+export { DiagnosticLogger, _InternalLogMessage } from './JavaScriptSDK/DiagnosticLogger';
+export { _InternalMessageId, LoggingSeverity } from './JavaScriptSDK.Enums/LoggingEnums';

--- a/cjs/package.json
+++ b/cjs/package.json
@@ -1,6 +1,6 @@
 {
     "name": "applicationinsights-core-js",
-    "version": "0.0.72",
+    "version": "0.0.74",
     "description": "Microsoft Application Insights Core Javascript SDK",
     "devDependencies": {
         "grunt": "1.0.1",


### PR DESCRIPTION
IDiagnosticLogger was not exported previously in core module