### PR TITLE
Add null baseType check; fix default logger constructor

### DIFF
--- a/JavaScriptSDK.Tests/Selenium/ApplicationInsightsCore.Tests.ts
+++ b/JavaScriptSDK.Tests/Selenium/ApplicationInsightsCore.Tests.ts
@@ -6,7 +6,7 @@ import { IConfiguration, ITelemetryPlugin, ITelemetryItem, IPlugin } from "../..
 import { AppInsightsCore } from "../../JavaScriptSDK/AppInsightsCore";
 import { IChannelControls } from "../../JavaScriptSDK.Interfaces/IChannelControls";
 import { _InternalMessageId, LoggingSeverity } from "../../JavaScriptSDK.Enums/LoggingEnums";
-import { _InternalLogMessage } from "../../JavaScriptSDK/DiagnosticLogger";
+import { _InternalLogMessage, DiagnosticLogger } from "../../JavaScriptSDK/DiagnosticLogger";
 
 export class ApplicationInsightsCoreTests extends TestClass {
 
@@ -117,6 +117,32 @@ export class ApplicationInsightsCoreTests extends TestClass {
         });
 
         this.testCase({
+            name: 'ApplicationInsightsCore: track adds required default fields if missing',
+            test: () => {
+                const expectedIKey: string = "09465199-12AA-4124-817F-544738CC7C41";
+                const expectedTimestamp = new Date();
+                const expectedBaseType = "EventData";
+
+                const channelPlugin = new ChannelPlugin();
+                const appInsightsCore = new AppInsightsCore();
+                appInsightsCore.initialize({instrumentationKey: expectedIKey}, [channelPlugin]);
+                const validateStub = this.sandbox.stub(appInsightsCore, "_validateTelmetryItem");
+
+                // Act
+                let bareItem: ITelemetryItem = {name: 'test item'};
+                appInsightsCore.track(bareItem);
+                this.clock.tick(1);
+
+                // Test
+                Assert.ok(validateStub.calledOnce, "validateTelemetryItem called");
+                const newItem: ITelemetryItem = validateStub.args[0][0];
+                Assert.equal(expectedIKey, newItem.instrumentationKey, "Instrumentation key is added");
+                Assert.equal(expectedBaseType, newItem.baseType, "BaseType is added");
+                Assert.deepEqual(expectedTimestamp, newItem.timestamp, "Timestamp is added");
+            }
+        });
+
+        this.testCase({
             name: "DiagnosticLogger: Critical logging history is saved",
             test: () => {
                 // Setup
@@ -133,6 +159,30 @@ export class ApplicationInsightsCoreTests extends TestClass {
 
                 // Act
                 appInsightsCore.logger.throwInternal(LoggingSeverity.CRITICAL, messageId, "Test Error");
+
+                // Test postcondition
+                Assert.ok(appInsightsCore.logger['_messageCount'] === 1, 'POST: Logging success');
+                Assert.ok(appInsightsCore.logger['_messageLogged'][messageKey], "POST: Correct messageId logged");
+            }
+        });
+
+        this.testCase({
+            name: 'DiagnosticLogger: Logger can be created with default constructor',
+            test: () => {
+                // setup
+                const channelPlugin = new ChannelPlugin();
+                const appInsightsCore = new AppInsightsCore();
+                appInsightsCore.initialize({instrumentationKey: "09465199-12AA-4124-817F-544738CC7C41"}, [channelPlugin]);
+                appInsightsCore.logger = new DiagnosticLogger();
+
+                const messageId: _InternalMessageId = _InternalMessageId.CannotAccessCookie; // can be any id
+                const messageKey = appInsightsCore.logger['AIInternalMessagePrefix'] + messageId;
+
+                // Verify precondition
+                Assert.ok(appInsightsCore.logger['_messageCount'] === 0, 'PRE: No internal logging performed yet');
+
+                // Act
+                appInsightsCore.logger.throwInternal(LoggingSeverity.CRITICAL, messageId, "Some message");
 
                 // Test postcondition
                 Assert.ok(appInsightsCore.logger['_messageCount'] === 1, 'POST: Logging success');

--- a/JavaScriptSDK/AppInsightsCore.ts
+++ b/JavaScriptSDK/AppInsightsCore.ts
@@ -145,6 +145,11 @@ export class AppInsightsCore implements IAppInsightsCore {
             this._notifiyInvalidEvent(telemetryItem);
             throw Error("Provide data.baseType for data.baseData");
         }
+        
+        if (!telemetryItem.baseType) {
+            // Hard coded from Common::Event.ts::Event.dataType
+            telemetryItem.baseType = "EventData";
+        }
 
         if (!telemetryItem.instrumentationKey) {
             // setup default ikey if not passed in
@@ -154,7 +159,7 @@ export class AppInsightsCore implements IAppInsightsCore {
             // add default timestamp if not passed in
             telemetryItem.timestamp = new Date();
         }
-
+ 
         // do basic validation before sending it through the pipeline
         this._validateTelmetryItem(telemetryItem);
 

--- a/JavaScriptSDK/DiagnosticLogger.ts
+++ b/JavaScriptSDK/DiagnosticLogger.ts
@@ -3,6 +3,7 @@ import { IConfiguration } from "../JavaScriptSDK.Interfaces/IConfiguration"
 import { _InternalMessageId, LoggingSeverity } from "../JavaScriptSDK.Enums/LoggingEnums";
 import { IDiagnosticLogger } from "../JavaScriptSDK.Interfaces/IDiagnosticLogger";
 import { CoreUtils } from "./CoreUtils";
+import { AppInsightsCore } from "./AppInsightsCore";
 
 export class _InternalLogMessage{
     public message: string;
@@ -86,6 +87,13 @@ export class DiagnosticLogger implements IDiagnosticLogger {
     private _messageLogged: { [type: number]: boolean } = {};
 
     constructor(config?: IConfiguration) {
+        if (CoreUtils.isNullOrUndefined(config)) {
+            // TODO: Use default config
+            // config = AppInsightsCore.defaultConfig;
+
+            // For now, use defaults specified in DiagnosticLogger members;
+            return;
+        }
         if (!CoreUtils.isNullOrUndefined(config.loggingLevelConsole)) {
             this.consoleLoggingLevel = () => { return config.loggingLevelConsole };
         }

--- a/amd/package.json
+++ b/amd/package.json
@@ -1,6 +1,6 @@
 {
     "name": "applicationinsights-core-js",
-    "version": "0.0.75",
+    "version": "0.0.79",
     "description": "Microsoft Application Insights Core Javascript SDK",
     "main": "bundle/applicationinsights-core-js.js",
     "types": "bundle/applicationinsights-core-js.d.ts",


### PR DESCRIPTION
DiagnosticLogger accepts a default constructor and will use default config options. No iKey will be configured.

When core.track is called, baseType, if not set, becomes "EventData" (custom event type)