### PR TITLE
Update logger defaults

### DIFF
--- a/JavaScriptSDK.Interfaces/IDiagnosticLogger.ts
+++ b/JavaScriptSDK.Interfaces/IDiagnosticLogger.ts
@@ -11,13 +11,13 @@ export interface IDiagnosticLogger {
     
     /**
      * 0: OFF
-     * 1: only critical
+     * 1: only critical (default)
      * 2: critical + info
      */
     consoleLoggingLevel: () => number;
 
     /**
-     * 0: OFF
+     * 0: OFF (default)
      * 1: CRITICAL
      * 2: WARNING
      */

--- a/JavaScriptSDK/DiagnosticLogger.ts
+++ b/JavaScriptSDK/DiagnosticLogger.ts
@@ -54,17 +54,17 @@ export class DiagnosticLogger implements IDiagnosticLogger {
 
     /**
      * 0: OFF
-     * 1: CRITICAL
+     * 1: CRITICAL (default)
      * 2: >= WARNING
      */
-    public consoleLoggingLevel = () => 0;
+    public consoleLoggingLevel = () => 1;
 
     /**
-     * 0: OFF
+     * 0: OFF (default)
      * 1: CRITICAL
      * 2: >= WARNING
      */
-    public telemetryLoggingLevel = () => 2;
+    public telemetryLoggingLevel = () => 0;
 
     /**
      * The maximum number of internal messages allowed to be sent per page view


### PR DESCRIPTION
Defaults:
- Turn on Critical only to console,
- turn off internal telemetry logging