### PR TITLE
ITelemetryItem: rename iKey, add ver

### DIFF
--- a/src/JavaScriptSDK.Interfaces/ITelemetryItem.ts
+++ b/src/JavaScriptSDK.Interfaces/ITelemetryItem.ts
@@ -7,6 +7,11 @@
  */
 export interface ITelemetryItem {
     /**
+     * CommonSchema Version of this SDK
+     */
+    ver?: string;
+
+    /**
      * Unique name of the telemetry item
      */
     name: string;
@@ -14,12 +19,12 @@ export interface ITelemetryItem {
     /**
      * Timestamp when item was sent
      */
-    timestamp?: Date;
+    time?: Date;
 
     /**
      * Identifier of the resource that uniquely identifies which resource data is sent to
      */
-    iKey?: string;
+    ikey?: string;
 
     /**
      * System context properties of the telemetry item, example: ip address, city etc
@@ -41,11 +46,6 @@ export interface ITelemetryItem {
      * Based on schema for part B
      */
     baseData?: { [key: string]: any };
-
-    /**
-     * CommonSchema Version of this SDK
-     */
-    ver?: number;
 
 }
 

--- a/src/JavaScriptSDK.Interfaces/ITelemetryItem.ts
+++ b/src/JavaScriptSDK.Interfaces/ITelemetryItem.ts
@@ -8,22 +8,22 @@
 export interface ITelemetryItem {
     /**
      * Unique name of the telemetry item
-     */ 
+     */
     name: string;
 
     /**
      * Timestamp when item was sent
-     */ 
+     */
     timestamp?: Date;
 
     /**
      * Identifier of the resource that uniquely identifies which resource data is sent to
-     */ 
-    instrumentationKey?: string;
+     */
+    iKey?: string;
 
     /**
      * System context properties of the telemetry item, example: ip address, city etc
-     */ 
+     */
     ctx?: {[key: string]: any};
 
     tags?: Tags[];
@@ -39,8 +39,13 @@ export interface ITelemetryItem {
 
     /**
      * Based on schema for part B
-     */ 
+     */
     baseData?: { [key: string]: any };
+
+    /**
+     * CommonSchema Version of this SDK
+     */
+    ver?: number;
 
 }
 

--- a/src/JavaScriptSDK.Interfaces/ITelemetryItem.ts
+++ b/src/JavaScriptSDK.Interfaces/ITelemetryItem.ts
@@ -19,7 +19,7 @@ export interface ITelemetryItem {
     /**
      * Timestamp when item was sent
      */
-    time?: Date;
+    time?: string;
 
     /**
      * Identifier of the resource that uniquely identifies which resource data is sent to

--- a/src/JavaScriptSDK.Tests/Selenium/ApplicationInsightsCore.Tests.ts
+++ b/src/JavaScriptSDK.Tests/Selenium/ApplicationInsightsCore.Tests.ts
@@ -25,12 +25,12 @@ export class ApplicationInsightsCoreTests extends TestClass {
             test: () => {
 
                 let samplingPlugin = new TestSamplingPlugin();
-                                
+
                 let appInsightsCore = new AppInsightsCore();
-                try {                    
+                try {
                     appInsightsCore.initialize(null, [samplingPlugin]);
                 } catch (error) {
-                    Assert.ok(true, "Validates configuration");                    
+                    Assert.ok(true, "Validates configuration");
                 }
 
                 let config2 : IConfiguration = {
@@ -39,17 +39,17 @@ export class ApplicationInsightsCoreTests extends TestClass {
                         extensionConfig: {}
                 };
 
-                try {                    
+                try {
                     appInsightsCore.initialize(config2, null);
                 } catch (error) {
-                    Assert.ok(true, "Validates extensions are provided");                    
+                    Assert.ok(true, "Validates extensions are provided");
                 }
                 let config : IConfiguration = {
                     endpointUrl: "https://dc.services.visualstudio.com/v2/track",
                     instrumentationKey: "",
                     extensionConfig: {}
                 };
-                try {                    
+                try {
                     appInsightsCore.initialize(config, [samplingPlugin]);
                 } catch (error) {
                     Assert.ok(true, "Validates instrumentationKey");
@@ -70,7 +70,7 @@ export class ApplicationInsightsCoreTests extends TestClass {
 
                 let appInsightsCore = new AppInsightsCore();
                 appInsightsCore.initialize(
-                    {instrumentationKey: "09465199-12AA-4124-817F-544738CC7C41"}, 
+                    {instrumentationKey: "09465199-12AA-4124-817F-544738CC7C41"},
                     [samplingPlugin, channelPlugin]);
                 Assert.ok(!!samplingPlugin.nexttPlugin, "setup prior to pipeline initialization");
             }
@@ -92,7 +92,7 @@ export class ApplicationInsightsCoreTests extends TestClass {
                 let appInsightsCore = new AppInsightsCore();
                 try {
                 appInsightsCore.initialize(
-                    {instrumentationKey: "09465199-12AA-4124-817F-544738CC7C41"}, 
+                    {instrumentationKey: "09465199-12AA-4124-817F-544738CC7C41"},
                     [samplingPlugin, samplingPlugin1, channelPlugin]);
 
                 Assert.ok("No error on dupicate priority");
@@ -108,9 +108,9 @@ export class ApplicationInsightsCoreTests extends TestClass {
                 let channelPlugin = new ChannelPlugin();
                 let appInsightsCore = new AppInsightsCore();
                 appInsightsCore.initialize(
-                    {instrumentationKey: "09465199-12AA-4124-817F-544738CC7C41"}, 
+                    {instrumentationKey: "09465199-12AA-4124-817F-544738CC7C41"},
                     [channelPlugin]);
-                
+
                 Assert.ok(!channelPlugin.isFlushInvoked, "Flush not called on initialize");
                 appInsightsCore.getTransmissionControls().forEach(queues => {
                     queues.forEach(q => q.flush(true));
@@ -140,7 +140,7 @@ export class ApplicationInsightsCoreTests extends TestClass {
                 // Test
                 Assert.ok(validateStub.calledOnce, "validateTelemetryItem called");
                 const newItem: ITelemetryItem = validateStub.args[0][0];
-                Assert.equal(expectedIKey, newItem.instrumentationKey, "Instrumentation key is added");
+                Assert.equal(expectedIKey, newItem.iKey, "Instrumentation key is added");
                 Assert.equal(expectedBaseType, newItem.baseType, "BaseType is added");
                 Assert.deepEqual(expectedTimestamp, newItem.timestamp, "Timestamp is added");
             }
@@ -441,7 +441,7 @@ class TestSamplingPlugin implements ITelemetryPlugin {
 
     private _start(config: IConfiguration) {
         if (!config) {
-            throw Error("required configuration missing");            
+            throw Error("required configuration missing");
         }
 
         let pluginConfig = config.extensions ? config.extensions[this.identifier] : null;
@@ -465,8 +465,8 @@ class ChannelPlugin implements IChannelControls {
     }
     public pause(): void {
         this.isPauseInvoked = true;
-    }    
-    
+    }
+
     public resume(): void {
         this.isResumeInvoked = true;
     }
@@ -485,7 +485,7 @@ class ChannelPlugin implements IChannelControls {
     public processTelemetry;
 
     public identifier = "Sender";
-    
+
     setNextPlugin(next: ITelemetryPlugin) {
         this._nextPlugin = next;
     }

--- a/src/JavaScriptSDK.Tests/Selenium/ApplicationInsightsCore.Tests.ts
+++ b/src/JavaScriptSDK.Tests/Selenium/ApplicationInsightsCore.Tests.ts
@@ -124,7 +124,7 @@ export class ApplicationInsightsCoreTests extends TestClass {
             name: 'ApplicationInsightsCore: track adds required default fields if missing',
             test: () => {
                 const expectedIKey: string = "09465199-12AA-4124-817F-544738CC7C41";
-                const expectedTimestamp = new Date();
+                const expectedTimestamp = new Date().toISOString();
                 const expectedBaseType = "EventData";
 
                 const channelPlugin = new ChannelPlugin();

--- a/src/JavaScriptSDK.Tests/Selenium/ApplicationInsightsCore.Tests.ts
+++ b/src/JavaScriptSDK.Tests/Selenium/ApplicationInsightsCore.Tests.ts
@@ -140,9 +140,9 @@ export class ApplicationInsightsCoreTests extends TestClass {
                 // Test
                 Assert.ok(validateStub.calledOnce, "validateTelemetryItem called");
                 const newItem: ITelemetryItem = validateStub.args[0][0];
-                Assert.equal(expectedIKey, newItem.iKey, "Instrumentation key is added");
+                Assert.equal(expectedIKey, newItem.ikey, "Instrumentation key is added");
                 Assert.equal(expectedBaseType, newItem.baseType, "BaseType is added");
-                Assert.deepEqual(expectedTimestamp, newItem.timestamp, "Timestamp is added");
+                Assert.deepEqual(expectedTimestamp, newItem.time, "Timestamp is added");
             }
         });
 

--- a/src/JavaScriptSDK/AppInsightsCore.ts
+++ b/src/JavaScriptSDK/AppInsightsCore.ts
@@ -175,7 +175,7 @@ export class AppInsightsCore implements IAppInsightsCore {
         }
         if (!telemetryItem.time) {
             // add default timestamp if not passed in
-            telemetryItem.time = new Date();
+            telemetryItem.time = new Date().toISOString();
         }
         if (CoreUtils.isNullOrUndefined(telemetryItem.ver)) {
             // CommonSchema 4.0
@@ -231,7 +231,7 @@ export class AppInsightsCore implements IAppInsightsCore {
                 const item: ITelemetryItem = {
                     name: "InternalMessageId: " + logMessage.messageId,
                     ikey: this.config.instrumentationKey,
-                    time: new Date(),
+                    time: new Date().toISOString(),
                     baseType: _InternalLogMessage.dataType,
                     baseData: { message: logMessage.message }
                 };

--- a/src/JavaScriptSDK/AppInsightsCore.ts
+++ b/src/JavaScriptSDK/AppInsightsCore.ts
@@ -45,7 +45,7 @@ export class AppInsightsCore implements IAppInsightsCore {
 
         this._notificationManager = new NotificationManager();
         this.config.extensions = CoreUtils.isNullOrUndefined(this.config.extensions) ? [] : this.config.extensions;
-        
+
         // add notification to the extensions in the config so other plugins can access it
         this.config.extensionConfig = CoreUtils.isNullOrUndefined(this.config.extensionConfig) ? {} : this.config.extensionConfig;
         this.config.extensionConfig.NotificationManager = this._notificationManager;
@@ -65,7 +65,7 @@ export class AppInsightsCore implements IAppInsightsCore {
             {
                 if (CoreUtils.isNullOrUndefined(item)) {
                     isValid = false;
-                }   
+                }
             });
 
             if (!isValid) {
@@ -108,7 +108,7 @@ export class AppInsightsCore implements IAppInsightsCore {
                 }
             }
         });
-        
+
         let c = -1;
         // Set next plugin for all until channel controller
         for (let idx = 0; idx < this._extensions.length - 1; idx++) {
@@ -128,7 +128,7 @@ export class AppInsightsCore implements IAppInsightsCore {
 
         // initialize channel controller first, this will initialize all channel plugins
         this._channelController.initialize(this.config, this, this._extensions);
-        
+
         // initialize remaining regular plugins
         this._extensions.forEach(ext => {
             let e = ext as ITelemetryPlugin;
@@ -163,21 +163,25 @@ export class AppInsightsCore implements IAppInsightsCore {
             this._notifiyInvalidEvent(telemetryItem);
             throw Error("Provide data.baseType for data.baseData");
         }
-        
+
         if (!telemetryItem.baseType) {
             // Hard coded from Common::Event.ts::Event.dataType
             telemetryItem.baseType = "EventData";
         }
 
-        if (!telemetryItem.instrumentationKey) {
+        if (!telemetryItem.iKey) {
             // setup default ikey if not passed in
-            telemetryItem.instrumentationKey = this.config.instrumentationKey;
+            telemetryItem.iKey = this.config.instrumentationKey;
         }
         if (!telemetryItem.timestamp) {
             // add default timestamp if not passed in
             telemetryItem.timestamp = new Date();
         }
- 
+        if (CoreUtils.isNullOrUndefined(telemetryItem.ver)) {
+            // CommonSchema 4.0
+            telemetryItem.ver = 4.0;
+        }
+
         // do basic validation before sending it through the pipeline
         this._validateTelmetryItem(telemetryItem);
 
@@ -210,9 +214,9 @@ export class AppInsightsCore implements IAppInsightsCore {
     removeNotificationListener(listener: INotificationListener): void {
         this._notificationManager.removeNotificationListener(listener);
     }
-    
+
     /**
-     * Periodically check logger.queue for 
+     * Periodically check logger.queue for
      */
     pollInternalLogs(): number {
         let interval = this.config.diagnosticLogInterval;
@@ -226,7 +230,7 @@ export class AppInsightsCore implements IAppInsightsCore {
             queue.forEach((logMessage: _InternalLogMessage) => {
                 const item: ITelemetryItem = {
                     name: "InternalMessageId: " + logMessage.messageId,
-                    instrumentationKey: this.config.instrumentationKey,
+                    iKey: this.config.instrumentationKey,
                     timestamp: new Date(),
                     baseType: _InternalLogMessage.dataType,
                     baseData: { message: logMessage.message }
@@ -250,7 +254,7 @@ export class AppInsightsCore implements IAppInsightsCore {
             throw Error("telemetry timestamp required");
         }
 
-        if (CoreUtils.isNullOrUndefined(telemetryItem.instrumentationKey)) {
+        if (CoreUtils.isNullOrUndefined(telemetryItem.iKey)) {
             this._notifiyInvalidEvent(telemetryItem);
             throw Error("telemetry instrumentationKey required");
         }
@@ -264,7 +268,7 @@ export class AppInsightsCore implements IAppInsightsCore {
 class ChannelController implements ITelemetryPlugin {
 
     private channelQueue: Array<IChannelControls[]>;
-    
+
     public processTelemetry (item: ITelemetryItem) {
         this.channelQueue.forEach(queues => {
             // pass on to first item in queue
@@ -292,7 +296,7 @@ class ChannelController implements ITelemetryPlugin {
                     queue = queue.sort((a,b) => { // sort based on priority within each queue
                         return a.priority - b.priority;
                     });
-                    
+
                     // Initialize each plugin
                     queue.forEach(queueItem => queueItem.initialize(config, core, extensions));
 
@@ -321,7 +325,7 @@ class ChannelController implements ITelemetryPlugin {
 
                 // Initialize each plugin
                 arr.forEach(queueItem => queueItem.initialize(config, core, extensions));
-                
+
                 // setup next plugin
                 for (let i = 1; i < arr.length; i++) {
                     arr[i - 1].setNextPlugin(arr[i]);
@@ -333,6 +337,6 @@ class ChannelController implements ITelemetryPlugin {
     }
 }
 
-const validationError = "Extensions must provide callback to initialize";    
+const validationError = "Extensions must provide callback to initialize";
 const ChannelControllerPriority = 200;
 const duplicatePriority = "One or more extensions are set at same priority";

--- a/src/JavaScriptSDK/AppInsightsCore.ts
+++ b/src/JavaScriptSDK/AppInsightsCore.ts
@@ -169,17 +169,17 @@ export class AppInsightsCore implements IAppInsightsCore {
             telemetryItem.baseType = "EventData";
         }
 
-        if (!telemetryItem.iKey) {
+        if (!telemetryItem.ikey) {
             // setup default ikey if not passed in
-            telemetryItem.iKey = this.config.instrumentationKey;
+            telemetryItem.ikey = this.config.instrumentationKey;
         }
-        if (!telemetryItem.timestamp) {
+        if (!telemetryItem.time) {
             // add default timestamp if not passed in
-            telemetryItem.timestamp = new Date();
+            telemetryItem.time = new Date();
         }
         if (CoreUtils.isNullOrUndefined(telemetryItem.ver)) {
             // CommonSchema 4.0
-            telemetryItem.ver = 4.0;
+            telemetryItem.ver = "4.0";
         }
 
         // do basic validation before sending it through the pipeline
@@ -230,8 +230,8 @@ export class AppInsightsCore implements IAppInsightsCore {
             queue.forEach((logMessage: _InternalLogMessage) => {
                 const item: ITelemetryItem = {
                     name: "InternalMessageId: " + logMessage.messageId,
-                    iKey: this.config.instrumentationKey,
-                    timestamp: new Date(),
+                    ikey: this.config.instrumentationKey,
+                    time: new Date(),
                     baseType: _InternalLogMessage.dataType,
                     baseData: { message: logMessage.message }
                 };
@@ -249,12 +249,12 @@ export class AppInsightsCore implements IAppInsightsCore {
             throw Error("telemetry name required");
         }
 
-        if (CoreUtils.isNullOrUndefined(telemetryItem.timestamp)) {
+        if (CoreUtils.isNullOrUndefined(telemetryItem.time)) {
             this._notifiyInvalidEvent(telemetryItem);
             throw Error("telemetry timestamp required");
         }
 
-        if (CoreUtils.isNullOrUndefined(telemetryItem.iKey)) {
+        if (CoreUtils.isNullOrUndefined(telemetryItem.ikey)) {
             this._notifiyInvalidEvent(telemetryItem);
             throw Error("telemetry instrumentationKey required");
         }


### PR DESCRIPTION
#### ITelemetryItem
- Rename `instrumentationKey` to `ikey`
- Rename `timestamp` to `time`, change type to `string`
- Add CommonSchema version number, `ver` as `string`